### PR TITLE
use foward slash so \( is not escaped

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A custom task that adds the Windows process ID (PID) into the application title 
 The bulk of the work is in [ShowPID.cs](https://github.com/cjdinger/SEGuideShowPID/blob/master/ShowPID.cs).  It's just a few lines of code that detects the process, grabs the Windows handle, then uses pinvoke methods to set the window title on the current SEGuide.exe process.
 
 To use the task:
- - Copy the TaskDLL/SEGuideShowPID.DLL to %appdata%\SAS\EnterpriseGuide\(ver)\Custom, where (ver) is the version of SAS Enterprise Guide you're running.
+ - Copy the TaskDLL/SEGuideShowPID.DLL to %appdata%/SAS/EnterpriseGuide/(ver)/Custom, where (ver) is the version of SAS Enterprise Guide you're running.
  - You might need to create the Custom subfolder in that location
  - The task should work with SAS Enterprise Guide 4.3 and later.
  - You might need to "unblock" the DLL [per these instructions](http://blogs.sas.com/content/sasdummy/2013/05/19/unblocking-custom-task-dlls/)


### PR DESCRIPTION
The README makes it look like (ver) is part of the EnterpriseGuide folder name. Forward slashes still work the same way, and make it more clear that (ver) is a folder within the EnterpriseGuide folder.